### PR TITLE
Import docx utilities

### DIFF
--- a/wizard.py
+++ b/wizard.py
@@ -5,11 +5,16 @@ from tkinter import ttk, messagebox
 from typing import List, Dict, Optional
 import re
 
+from docx import Document
 from config import Config
 from ui_utils import UIUtils
 from document_parser import DocumentParser
 from validators import validate_by_type
-from variable_utils import normalize_variable_name
+from variable_utils import (
+    normalize_variable_name,
+    iter_all_paragraphs,
+    iter_all_text_nodes,
+)
 # Wizard UI
 class WizardUI(tk.Toplevel):
     """Wizard UI for interactive logic block processing."""


### PR DESCRIPTION
## Summary
- ensure wizard can fill variables by importing python-docx Document and iter helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests'; ModuleNotFoundError: No module named 'docx')*

------
https://chatgpt.com/codex/tasks/task_e_689cb755a08c832d8005a3d955f2c299